### PR TITLE
deactivate PHP.UpperCaseConstant rule

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -129,7 +129,7 @@
  <rule ref="Generic.PHP.DeprecatedFunctions" />
  <rule ref="Generic.PHP.DisallowShortOpenTag" />
  <rule ref="Generic.PHP.LowerCaseKeyword" />
- <rule ref="Generic.PHP.UpperCaseConstant" />
+ <!-- <rule ref="Generic.PHP.UpperCaseConstant" /> -->
  <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
 
  <!-- Use Unix newlines -->


### PR DESCRIPTION
I appreciate this maybe controversial, but seem worth discussing?

The change is justifiable on the basis that:

* The [PSR-2](http://www.php-fig.org/psr/psr-2/) standard requires `true`, `false` and `null` to be in lower case.
* [PHP](http://php.net/manual/en/language.types.boolean.php) does not actually care.
* although [json_decode() will soon reject non-lowercase variants of the JSON literals](https://php.net/manual/en/migration56.incompatible.php), as per the JSON specification
* JavaScript booleans are lowercase and case-sensitive
* [edit] Oh and just discovered that [symfony uses lower too](http://symfony.com/doc/current/contributing/code/standards.html)...
