### PR TITLE
Ensure that finally operator is correctly tagged as opened so that in…

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -952,6 +952,8 @@ class Drupal_Sniffs_WhiteSpace_ScopeIndentSniff implements PHP_CodeSniffer_Sniff
                 }
 
                 $condition = $tokens[$tokens[$i]['scope_condition']]['code'];
+                // Hack for T_FINALLY to be properly opened
+                PHP_CodeSniffer_Tokens::$scopeOpeners[351] = 351;
                 if (isset(PHP_CodeSniffer_Tokens::$scopeOpeners[$condition]) === true
                     && in_array($condition, $this->nonIndentingScopes) === false
                 ) {


### PR DESCRIPTION
…denting is set correctly

We have seen just recently we got our first block of code using finally { }

As evidenced by https://test.civicrm.org/job/CiviCRM-Core-PR/18710/checkstyleResult/new/ it seems our current code sniffing doesn't pickup the opening brace of the finally { for some reason. 

This adds in the opening brace so it knows to add an extra 2 spaces into the expected indent

ping @totten @colemanw 