### PR TITLE
Re-instate checking on IncorrectVarType

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -62,7 +62,6 @@
  <rule ref="Drupal.Commenting.InlineComment.SpacingBefore"><severity>0</severity></rule>
  <rule ref="Drupal.Commenting.InlineComment.WrongStyle"><severity>0</severity></rule>
  <rule ref="Drupal.Commenting.VariableComment.IncorrectParamVarName"><severity>0</severity></rule>
- <rule ref="Drupal.Commenting.VariableComment.IncorrectVarType"><severity>0</severity></rule>
  <rule ref="Drupal.Files.LineLength.TooLong"><severity>0</severity></rule>
  <rule ref="Drupal.Strings.UnnecessaryStringConcat.Found"><severity>0</severity></rule>
  <rule ref="Drupal.Formatting.MultipleStatementAlignment.NotSame"><severity>0</severity></rule>


### PR DESCRIPTION
@totten @seamuslee001 I ran phpcs with this change & while it surfaced a number - see https://github.com/civicrm/civicrm-core/pull/14296/files and https://github.com/civicrm/civicrm-core/pull/14294 - I feel like the incidence is low enough that it would not impose undue burden to remove this one & raise our bar a little. I think there are still a couple left in the DAOs with those 2 merged (timestamp needs to be string) but I think it's pretty trivial to resolve