### PR TITLE
civicrm-buildkit#535 - Allow the civix `E` helper

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Classes/UnusedUseStatementSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Classes/UnusedUseStatementSniff.php
@@ -71,6 +71,10 @@ class UnusedUseStatementSniff implements Sniff
             return;
         }
 
+        if ($tokens[$classPtr]['content'] == 'E') {
+            return;
+        }
+
         // Search where the class name is used. PHP treats class names case
         // insensitive, that's why we cannot search for the exact class name string
         // and need to iterate over all T_STRING tokens in the file.


### PR DESCRIPTION
The civix `E` helper is meant to be a starting point that's readily
available in all civix-based templates.  However, it has to to be
prepopulated in *anticipation* that someone will use it (regardless of
whether it's initially needed in the bare template).

Patch originally written by @twomice. I've done some light testing on a few files.

https://github.com/civicrm/civicrm-buildkit/issues/535