### PR TITLE
Prevent misspellings of SEPARATOR

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -45,6 +45,10 @@ class ValidVariableNameSniff extends AbstractVariableSniff
 
         $memberName = ltrim($tokens[$stackPtr]['content'], '$');
 
+        if (preg_match('/seperator|separater|seperater|seperetor/i', $memberName) === 1) {
+          $phpcsFile->addError("$memberName contains incorrect spelling of the word separator", $stackPtr, 'MisspelledSeparator');
+        }
+
         if (strpos($memberName, '_') === false) {
             return;
         }
@@ -110,6 +114,10 @@ class ValidVariableNameSniff extends AbstractVariableSniff
         if (preg_match('/^[A-Z]/', $varName) === 1) {
             $error = "Variable \"$varName\" starts with a capital letter, but only \$lowerCamelCase or \$snake_case is allowed";
             $phpcsFile->addError($error, $stackPtr, 'LowerStart');
+        }
+
+        if (preg_match('/seperator|separater|seperater|seperetor/i', $varName) === 1) {
+          $phpcsFile->addError("$varName contains incorrect spelling of the word separator", $stackPtr, 'MisspelledSeparator');
         }
 
     }//end processVariable()

--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -80,6 +80,7 @@
  <rule ref="Drupal.NamingConventions.ValidVariableName"><severity>0</severity></rule>
  <rule ref="Drupal.NamingConventions.ValidVariableName.LowerCamelName"><severity>0</severity></rule>
  <rule ref="Drupal.NamingConventions.ValidVariableName.LowerCamelName"><severity>0</severity></rule>
+ <rule ref="Drupal.NamingConventions.ValidVariableName.MisspelledSeparator"><severity>5</severity></rule>
  <rule ref="Drupal.Semantics.RemoteAddress.RemoteAddress"><severity>0</severity></rule>
 
  <!-- CIVICRM: These excludes should be targetted at specific files, but I'm having trouble with exclude-pattern-->


### PR DESCRIPTION
Inspired by https://github.com/civicrm/civicrm-core/pull/18238 and a history in civi that goes back I think forever of repeatedly misspelling this word.

I had to add the line in ruleset.xml with severity 5 to get it to work. That doesn't seem right but I'm not really familiar with customizing sniffer and the "5" came from running with -vvv where the message wasn't clear but seemed like it was skipping it because it wasn't "5".