### PR TITLE
Offset access syntax with curly braces is deprecated

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -431,7 +431,7 @@ class FunctionCommentSniff implements Sniff
                 }
 
                 // Starts with a capital letter and ends with a fullstop.
-                $firstChar = $comment{0};
+                $firstChar = $comment[0];
                 if (strtoupper($firstChar) !== $firstChar) {
                     $error = '@throws tag comment must start with a capital letter';
                     $phpcsFile->addError($error, $throwStart, 'ThrowsNotCapital');

--- a/coder_sniffer/Drupal/Sniffs/Commenting/InlineCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/InlineCommentSniff.php
@@ -143,7 +143,7 @@ class InlineCommentSniff implements Sniff
             }
         }//end if
 
-        if ($tokens[$stackPtr]['content']{0} === '#') {
+        if ($tokens[$stackPtr]['content'][0] === '#') {
             $error = 'Perl-style comments are not allowed; use "// Comment" instead';
             $fix   = $phpcsFile->addFixableError($error, $stackPtr, 'WrongStyle');
             if ($fix === true) {

--- a/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidGlobalSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/NamingConventions/ValidGlobalSniff.php
@@ -110,7 +110,7 @@ class ValidGlobalSniff implements Sniff
         while (($varToken = $phpcsFile->findNext($ignore, ($varToken + 1), null, true, null, true)) !== false) {
             if ($tokens[$varToken]['code'] === T_VARIABLE
                 && in_array($tokens[$varToken]['content'], $this->coreGlobals) === false
-                && $tokens[$varToken]['content']{1} !== '_'
+                && $tokens[$varToken]['content'][1] !== '_'
                 && !preg_match('/^\$(wp|civi|Civi)/', $tokens[$varToken]['content'])
             ) {
                 $error = 'global variables should start with a single underscore followed by the module and another underscore';

--- a/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/FunctionTSniff.php
@@ -118,7 +118,7 @@ class FunctionTSniff extends FunctionCall
 
         // Check if there is a backslash escaped single quote in the string and
         // if the string makes use of double quotes.
-        if ($string{0} === "'" && strpos($string, "\'") !== false
+        if ($string[0] === "'" && strpos($string, "\'") !== false
             && strpos($string, '"') === false
         ) {
             $warn = 'Avoid backslash escaping in translatable strings when possible, use "" quotes instead';
@@ -126,7 +126,7 @@ class FunctionTSniff extends FunctionCall
             return;
         }
 
-        if ($string{0} === '"' && strpos($string, '\"') !== false
+        if ($string[0] === '"' && strpos($string, '\"') !== false
             && strpos($string, "'") === false
         ) {
             $warn = "Avoid backslash escaping in translatable strings when possible, use '' quotes instead";

--- a/coder_sniffer/Drupal/Sniffs/Semantics/LStringTranslatableSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Semantics/LStringTranslatableSniff.php
@@ -59,7 +59,7 @@ class LStringTranslatableSniff extends FunctionCall
         $argument = $this->getArgument(1);
         if ($tokens[$argument['start']]['code'] === T_CONSTANT_ENCAPSED_STRING
             // If the string starts with a HTML tag we don't complain.
-            && $tokens[$argument['start']]['content']{1} !== '<'
+            && $tokens[$argument['start']]['content'][1] !== '<'
         ) {
             $error = 'The $text argument to l() should be enclosed within t() so that it is translatable';
             $phpcsFile->addError($error, $stackPtr, 'LArg');

--- a/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/WhiteSpace/ScopeIndentSniff.php
@@ -816,7 +816,7 @@ class ScopeIndentSniff implements Sniff
             // Comments starting with a star have an extra whitespace.
             if ($checkToken !== null && $tokens[$checkToken]['code'] === T_COMMENT) {
                 $content = trim($tokens[$checkToken]['content']);
-                if ($content{0} === '*') {
+                if ($content[0] === '*') {
                     $checkIndent += 1;
                 }
             }


### PR DESCRIPTION
Fixes fatal error on 7.4

```
Deprecated: Array and string offset access syntax with curly braces is deprecated in /Users/mglaman/civicrm-buildkit/vendor/drupal/coder/coder_sniffer/Drupal/Sniffs/Commenting/InlineCommentSniff.php on line 146
```

See upstream fix: https://git.drupalcode.org/project/coder/-/blob/8.x-3.x/coder_sniffer/Drupal/Sniffs/Commenting/InlineCommentSniff.php#L140