### PR TITLE
Permit array shapes

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FunctionCommentSniff.php
@@ -342,7 +342,7 @@ class FunctionCommentSniff implements Sniff
                     }
 
                     $phpcsFile->addError($error, $return, 'MissingReturnComment');
-                } else if (strpos($type, ' ') !== false) {
+                } else if (strpos($type, ' ') !== false && strpos($type, 'array{') !== 0) {
                     if (preg_match('/^([^\s]+)[\s]+(\$[^\s]+)[\s]*$/', $type, $matches) === 1) {
                         $error = 'Return type must not contain variable name "%s"';
                         $data  = array($matches[2]);
@@ -671,11 +671,11 @@ class FunctionCommentSniff implements Sniff
                 $param['type'] = preg_replace('/\s+\.{3}$/', '', $param['type']);
             }
 
-            if (preg_match('/\s/', $param['type'])) {
+            if (preg_match('/\s/', $param['type']) && strpos($param['type'], 'array{') !== 0) {
                 $error = 'Parameter type "%s" must not contain spaces';
                 $data  = array($param['type']);
                 $phpcsFile->addError($error, $param['tag'], 'ParamTypeSpaces', $data);
-            } else if ($param['type'] !== $suggestedType) {
+            } else if ($param['type'] !== $suggestedType && strpos($param['type'], 'array{') !== 0) {
                 $error = 'Expected "%s" but found "%s" for parameter type';
                 $data  = array(
                           $suggestedType,

--- a/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/VariableCommentSniff.php
@@ -145,7 +145,7 @@ class VariableCommentSniff extends AbstractVariableSniff
             if ($fix === true) {
                 $phpcsFile->fixer->replaceToken(($foundVar + 2), $matches[1]);
             }
-        } else if ($varType !== $suggestedType) {
+        } else if ($varType !== $suggestedType && strpos($varType, 'array{') !== 0) {
             $error = 'Expected "%s" but found "%s" for @var tag in member variable comment';
             $data  = array(
                       $suggestedType,


### PR DESCRIPTION
Suppress false-positive errors with the new array shapes syntax:

https://blog.jetbrains.com/phpstorm/2021/07/phpstorm-2021-2-release/#array_shapes_phpdoc_syntax_support