### PR TITLE
Enable `IncorrectParamVarName` - Slight tightening of rules

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -63,7 +63,6 @@
  <rule ref="Drupal.Commenting.InlineComment.SpacingAfter"><severity>0</severity></rule>
  <rule ref="Drupal.Commenting.InlineComment.SpacingBefore"><severity>0</severity></rule>
  <rule ref="Drupal.Commenting.InlineComment.WrongStyle"><severity>0</severity></rule>
- <rule ref="Drupal.Commenting.VariableComment.IncorrectParamVarName"><severity>0</severity></rule>
  <rule ref="Drupal.Files.LineLength.TooLong"><severity>0</severity></rule>
  <rule ref="Drupal.Strings.UnnecessaryStringConcat.Found"><severity>0</severity></rule>
  <rule ref="Drupal.Formatting.MultipleStatementAlignment.NotSame"><severity>0</severity></rule>


### PR DESCRIPTION
Per https://github.com/civicrm/civicrm-core/pull/22515 there are a handful of these- we
can fix the bulk of them pretty easily