### PR TITLE
FileCommentSniff.php - Fix warning when running on php82

### DIFF
--- a/coder_sniffer/Drupal/Sniffs/Commenting/FileCommentSniff.php
+++ b/coder_sniffer/Drupal/Sniffs/Commenting/FileCommentSniff.php
@@ -29,6 +29,11 @@ use PHP_CodeSniffer\Sniffs\Sniff;
 class FileCommentSniff implements Sniff
 {
 
+    /**
+     * @var \PHP_CodeSniffer\Files\File|null
+     */
+    public $currentFile = NULL;
+
 
     /**
      * A list of tokenizers this sniff supports.


### PR DESCRIPTION
If you run civilint in PHP 8.2, you may sometimes get this warning. It is not a problem in your own file -- it's a problem within the linter.

```

FILE: /home/totten/src/civix/src/CRM/CivixBundle/Builder/Collection.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 1 | ERROR | An error occurred during processing; checking has been aborted.
   |       | The error message was: Creation of dynamic property
   |       | Drupal\Sniffs\Commenting\FileCommentSniff::$currentFile is
   |       | deprecated in
   |       | /home/totten/bknix/vendor/drupal/coder/coder_sniffer/Drupal/Sniffs/Commenting/FileCommentSniff.php
   |       | on line 67
   |       | The error originated in the Drupal.Commenting.FileComment sniff on
   |       | line 67.
--------------------------------------------------------------------------------

```