### PR TITLE
ruleset.xml - Opt-out of malfunctioning/deprecated CSS linting rule

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -305,6 +305,9 @@
   <severity>0</severity>
  </rule>
 
+ <rule ref="Squiz.CSS.SemicolonSpacing.NotAtEnd">
+  <severity>0</severity>
+ </rule>
  <rule ref="Squiz.CSS.ClassDefinitionClosingBraceSpace" />
  <rule ref="Squiz.CSS.ClassDefinitionClosingBraceSpace.SpacingAfterClose">
   <severity>0</severity>


### PR DESCRIPTION
As observed in https://github.com/civicrm/civicrm-core/pull/31478, this rule is causing trouble when the CSS file has CSS-variables. Additionally, CSS support in `phpcs` is now considered deprecated in 3.x (*scheduled for removal in 4.x*).