### PR TITLE
Hush, `Drupal.CSS.ClassDefinitionNameSpacing`

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -64,6 +64,7 @@
  <rule ref="Drupal.Commenting.InlineComment.SpacingBefore"><severity>0</severity></rule>
  <rule ref="Drupal.Commenting.InlineComment.WrongStyle"><severity>0</severity></rule>
  <rule ref="Drupal.Commenting.VariableComment.IncorrectParamVarName"><severity>0</severity></rule>
+ <rule ref="Drupal.CSS.ClassDefinitionNameSpacing"><severity>0</severity></rule>
  <rule ref="Drupal.Files.LineLength.TooLong"><severity>0</severity></rule>
  <rule ref="Drupal.Strings.UnnecessaryStringConcat.Found"><severity>0</severity></rule>
  <rule ref="Drupal.Formatting.MultipleStatementAlignment.NotSame"><severity>0</severity></rule>


### PR DESCRIPTION
Suppose you have a CSS directive like this:

```css
.foo .bar:not(.apple,.banana,.cherry,.date) {
  yaddayadda: 1px;
}
```

This rule forces you to split it out like:

```css
.foo .bar:not(.apple,
.banana,
.cherry,
.date) {
  yaddayadda: 1px;
}
```

But then it looks like `.banana` and `.cherry` and `.date` are entirely separate expressions. In fact, they are nested. But I can't find any sensible way to indicate the nesting while _also_ passing this rule.

So let's just disable this rule?

(cc @vingle)