### PR TITLE
Disable Drupal.Commenting.DataTypeNamespace sniff

### DIFF
--- a/coder_sniffer/Drupal/ruleset.xml
+++ b/coder_sniffer/Drupal/ruleset.xml
@@ -74,6 +74,7 @@
  <!-- CIVICRM: These rules are distinctly inappropriate -->
  <rule ref="Drupal.Classes.InterfaceName.InterfaceSuffix"><severity>0</severity></rule>
  <rule ref="Drupal.Classes.FullyQualifiedNamespace"><severity>0</severity></rule>
+ <rule ref="Drupal.Commenting.DataTypeNamespace"><severity>0</severity></rule>
  <rule ref="Drupal.NamingConventions.ValidClassName.NoUnderscores"><severity>0</severity></rule>
  <rule ref="Drupal.NamingConventions.ValidFunctionName.InvalidName"><severity>0</severity></rule>
  <rule ref="Drupal.NamingConventions.ValidFunctionName.NotCamelCaps"><severity>0</severity></rule>


### PR DESCRIPTION
Before
-------
When you run `civilint` it will complain if your docblocks don't use fully namespaced classes in their comments. E.g. you have to say

```php
  /**
   * @param \Civi\Afform\FormDataModel $model
   */
```

Even though PHPStorm is perfectly happy with:

```php
  /**
   * @param FormDataModel $model
   */
```

But CiviLint still complains:

```
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 14 | ERROR | [x] Data types in @param tags need to be fully
    |       |     namespaced
----------------------------------------------------------------------
```

This is annoying and pointless. Imported classes work fine in comments.

After
----------
PHPStorm is happy, civilint is happy, I'm happy.